### PR TITLE
Rename `finally_t` -> `finalizer`

### DIFF
--- a/provides/include/dumpster_v1/finally.hpp
+++ b/provides/include/dumpster_v1/finally.hpp
@@ -4,24 +4,24 @@
 
 #include <utility>
 
-template <class Action> dumpster_v1::Private::finally_t<Action>::~finally_t() {
+template <class Action> dumpster_v1::Private::finalizer<Action>::~finalizer() {
   m_action();
 }
 
 template <class Action>
 template <class ForwardableAction>
-dumpster_v1::Private::finally_t<Action>::finally_t(ForwardableAction &&action)
+dumpster_v1::Private::finalizer<Action>::finalizer(ForwardableAction &&action)
     : m_action(std::forward<ForwardableAction>(action)) {}
 
-template <class Action> dumpster_v1::finally_t<Action>::~finally_t() {}
+template <class Action> dumpster_v1::finalizer<Action>::~finalizer() {}
 
 template <class Action>
 template <class ForwardableAction>
-dumpster_v1::finally_t<Action>::finally_t(ForwardableAction &&action)
-    : Private::finally_t<Action>(std::forward<ForwardableAction>(action)) {}
+dumpster_v1::finalizer<Action>::finalizer(ForwardableAction &&action)
+    : Private::finalizer<Action>(std::forward<ForwardableAction>(action)) {}
 
 template <class Action>
-dumpster_v1::finally_t<std::remove_cvref_t<Action>>
+dumpster_v1::finalizer<std::remove_cvref_t<Action>>
 dumpster_v1::finally(Action &&action) {
-  return finally_t<std::remove_cvref_t<Action>>(std::forward<Action>(action));
+  return finalizer<std::remove_cvref_t<Action>>(std::forward<Action>(action));
 }

--- a/provides/include/dumpster_v1/private.hpp
+++ b/provides/include/dumpster_v1/private.hpp
@@ -4,22 +4,22 @@
 
 namespace dumpster_v1 {
 
-template <class Value> struct finally_t;
+template <class Value> struct finalizer;
 
 class Private {
-  template <class> friend struct finally_t;
+  template <class> friend struct finalizer;
 
-  template <class Value> class finally_t;
+  template <class Value> class finalizer;
 };
 
 } // namespace dumpster_v1
 
-template <class Action> class dumpster_v1::Private::finally_t {
-  template <class> friend struct dumpster_v1::finally_t;
+template <class Action> class dumpster_v1::Private::finalizer {
+  template <class> friend struct dumpster_v1::finalizer;
 
-  ~finally_t();
+  ~finalizer();
 
-  template <class ForwardableAction> finally_t(ForwardableAction &&action);
+  template <class ForwardableAction> finalizer(ForwardableAction &&action);
 
   std::conditional_t<std::is_function_v<Action>, Action *, Action> m_action;
 };

--- a/provides/include/dumpster_v1/synopsis.hpp
+++ b/provides/include/dumpster_v1/synopsis.hpp
@@ -33,23 +33,23 @@ template <class Value> using zeroed = defaulted<Value, static_cast<Value>(0)>;
 // finally.hpp =================================================================
 
 /// Finalizer that invokes stored action when destroyed.
-template <class Action> struct finally_t : Private::finally_t<Action> {
+template <class Action> struct finalizer : Private::finalizer<Action> {
   /// Calls the finalizing action given to the constructor.
-  ~finally_t();
+  ~finalizer();
 
   /// Constructs a finalizer from the given finalizing action.
-  template <class ForwardableAction> finally_t(ForwardableAction &&action);
+  template <class ForwardableAction> finalizer(ForwardableAction &&action);
 
   /// Finalizers are not CopyConstructible.
-  finally_t(const finally_t &) = delete;
+  finalizer(const finalizer &) = delete;
 
   /// Finalizers are not CopyAssignable.
-  finally_t &operator=(const finally_t &) = delete;
+  finalizer &operator=(const finalizer &) = delete;
 };
 
 /// Creates a finalizer that invokes the action when destroyed.
 template <class Action>
-finally_t<std::remove_cvref_t<Action>> finally(Action &&action);
+finalizer<std::remove_cvref_t<Action>> finally(Action &&action);
 
 // insertion_sort.hpp ==========================================================
 


### PR DESCRIPTION
This is technically a breaking change, but I'm going to let that slip as nobody
should be referring to `finally_t` by name.